### PR TITLE
Added now playing function

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nlopes/slack"
+	"github.com/zmb3/spotify"
+)
+
+func nowPlaying(rtm *slack.RTM, channel string, playerState *spotify.PlayerState) error {
+	artist := playerState.CurrentlyPlaying.Item.Artists[0].Name
+	track := playerState.CurrentlyPlaying.Item.Name
+	album := playerState.CurrentlyPlaying.Item.Album.Name
+	postMsgParams := slack.NewPostMessageParameters()
+	postMsgParams.AsUser = true
+	_, _, err := rtm.PostMessage(channel, fmt.Sprintf("Artist: %s\nTrack: %s\nAlbum: %s", artist, track, album), postMsgParams)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 			prefix := fmt.Sprintf("<@%s> ", info.User.ID)
 
 			if ev.User != info.User.ID && strings.HasPrefix(ev.Text, prefix) {
-				respond(rtm, ev, prefix, client)
+				respond(rtm, ev, prefix, client, playerState)
 			}
 
 		case *slack.PresenceChangeEvent:
@@ -101,7 +101,7 @@ func main() {
 	}
 }
 
-func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spotify.Client) {
+func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spotify.Client, playerState *spotify.PlayerState) {
 	text := msg.Text
 	text = strings.TrimPrefix(text, prefix)
 	text = strings.TrimSpace(text)
@@ -116,12 +116,12 @@ func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spo
 		err = client.Next()
 	case "previous":
 		err = client.Previous()
+	case "now playing":
+		err = nowPlaying(rtm, msg.Channel, playerState)
 	}
 	if err != nil {
 		log.Print(err)
 	}
-
-	client.Play()
 
 	fmt.Printf("%v", text)
 }


### PR DESCRIPTION
Added a function which takes the slack command `@bot now playing` and the bot will then print a message to the same channel the command was run in displaying the artist, track title and album of the track currently playing. Also fixed the bug with the track beginning to play again after being paused.

![spotify_now_playing](https://user-images.githubusercontent.com/22451262/29998119-b440f0a4-901a-11e7-9df3-9b12af4b73a5.gif)
