### PR TITLE
Added Search Command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,21 +1,94 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/nlopes/slack"
 	"github.com/zmb3/spotify"
 )
 
-func nowPlaying(rtm *slack.RTM, channel string, playerState *spotify.PlayerState) error {
-	artist := playerState.CurrentlyPlaying.Item.Artists[0].Name
-	track := playerState.CurrentlyPlaying.Item.Name
-	album := playerState.CurrentlyPlaying.Item.Album.Name
+func nowPlaying(rtm *slack.RTM, channel string, client *spotify.Client) error {
 	postMsgParams := slack.NewPostMessageParameters()
 	postMsgParams.AsUser = true
-	_, _, err := rtm.PostMessage(channel, fmt.Sprintf("Artist: %s\nTrack: %s\nAlbum: %s", artist, track, album), postMsgParams)
+	currentlyPlaying, err := client.PlayerCurrentlyPlaying()
+	if err != nil {
+		rtm.PostMessage(channel, "Unable to get currently playing track.", postMsgParams)
+		return err
+	}
+	artist := currentlyPlaying.Item.Artists[0].Name
+	track := currentlyPlaying.Item.Name
+	album := currentlyPlaying.Item.Album.Name
+	_, _, err = rtm.PostMessage(channel, fmt.Sprintf("Artist: %s\nTrack: %s\nAlbum: %s", artist, track, album), postMsgParams)
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func search(rtm *slack.RTM, text, channel string, client *spotify.Client) error {
+	var searchMap map[string]string
+	var searchSlice []string
+	searchMap = make(map[string]string)
+
+	postParams := slack.NewPostMessageParameters()
+	postParams.AsUser = true
+
+	// First we remove the term search from the beginning of the string
+	// and trim any trailing space
+	text = strings.TrimPrefix(text, "search")
+	text = strings.TrimSpace(text)
+
+	// Split on the seperator to turn the string into a slice of strings
+	// for each section of the track to be searched
+	searchSlice = strings.Split(text, ",")
+
+	for _, str := range searchSlice {
+		// Split the string into parts on the seperator
+		// e.g. for the string "Artist: Some Person"
+		parts := strings.Split(str, ":")
+
+		// Place the parts into the map with index 0 as the key and index 1 as the value
+		// trimming any trailing space
+		parts[0] = strings.ToLower(parts[0])
+		parts[1] = strings.ToLower(parts[1])
+		searchMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+
+	// Check to ensure that all of the required parameters have been specified in the command
+	if _, ok := searchMap["artist"]; !ok {
+		rtm.PostMessage(channel, fmt.Sprintf("Missing parameter Artist in search command\nSearch should be in the format: `@bot search Artist: Someone, Track: Some Track`"), postParams)
+		return fmt.Errorf("Missing parameter Artist in search command\nSearch should be in the format: `@bot search Artist: Someone, Track: Some Track`")
+	}
+
+	if _, ok := searchMap["track"]; !ok {
+		rtm.PostMessage(channel, fmt.Sprintf("Missing parameter Track in search command\nSearch should be in the format: `@bot search Artist: Someone, Track: Some Track`"), postParams)
+		return fmt.Errorf("Missing parameter Track in search command\nSearch should be in the format: `@bot search Artist: Someone, Track: Some Track`")
+	}
+
+	searchQuery := fmt.Sprintf("artist:%s track:%s", searchMap["artist"], searchMap["track"])
+	results, err := client.Search(searchQuery, spotify.SearchTypeTrack)
+	if err != nil {
+		return err
+	}
+
+	// If no results are found send a message to notify of this and return an error
+	if len(results.Tracks.Tracks) < 1 {
+		rtm.PostMessage(channel, fmt.Sprintf("No results found for Artist: %s and Track: %s", searchMap["artist"], searchMap["track"]), postParams)
+		return errors.New("no results found for query")
+	}
+
+	// Range over the results, append them to the results message and send a slack message to display these
+	var resultsMsg string
+	for _, result := range results.Tracks.Tracks {
+		resultsMsg = fmt.Sprintf("%s\nTrack Title: %s\nArtist: %s\nAlbum: %s\n", resultsMsg, result.Name, result.Artists[0].Name, result.Album.Name)
+	}
+
+	_, _, err = rtm.PostMessage(channel, resultsMsg, postParams)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 			prefix := fmt.Sprintf("<@%s> ", info.User.ID)
 
 			if ev.User != info.User.ID && strings.HasPrefix(ev.Text, prefix) {
-				respond(rtm, ev, prefix, client, playerState)
+				respond(rtm, ev, prefix, client)
 			}
 
 		case *slack.PresenceChangeEvent:
@@ -101,12 +101,15 @@ func main() {
 	}
 }
 
-func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spotify.Client, playerState *spotify.PlayerState) {
+func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spotify.Client) {
+	var err error
 	text := msg.Text
 	text = strings.TrimPrefix(text, prefix)
 	text = strings.TrimSpace(text)
 	text = strings.ToLower(text)
-	var err error
+	if ok := strings.HasPrefix(text, "search"); ok {
+		err = search(rtm, text, msg.Channel, client)
+	}
 	switch text {
 	case "play":
 		err = client.Play()
@@ -117,7 +120,7 @@ func respond(rtm *slack.RTM, msg *slack.MessageEvent, prefix string, client *spo
 	case "previous":
 		err = client.Previous()
 	case "now playing":
-		err = nowPlaying(rtm, msg.Channel, playerState)
+		err = nowPlaying(rtm, msg.Channel, client)
 	}
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
This PR adds a search command using the syntax `@bot search Artist: Artist Name, Track: Track Title` and returns the results as a slack message or returns a slack message to advise of no results found.

This PR also contains a fix for the `now playing` command not updating correctly

![spotify_search](https://user-images.githubusercontent.com/22451262/29998859-33c591ec-902d-11e7-99f2-7e93d4dd75a9.gif)
