### PR TITLE
Added ban command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -187,7 +187,8 @@ func addToBannedList(rtm *slack.RTM, text, channel, slackUserID string, client *
 
 	for _, track := range playlistTracks.Tracks {
 		for _, art := range track.Track.Artists {
-			if strings.Contains(art.Name, artist) {
+			artistName := strings.ToLower(art.Name)
+			if strings.Contains(artistName, artist) {
 				_, err = client.RemoveTracksFromPlaylist(spotifyUser.ID, playlist.ID, track.Track.ID)
 				if err != nil {
 					rtm.PostMessage(channel, fmt.Sprintf("Unable to remove tracks by artist: %s from the playlist.", artist), postParams)

--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ func main() {
 		}
 
 		fmt.Printf("Found your %s (%s)\n", playerState.Device.Type, playerState.Device.Name)
-		fmt.Printf("\nPlaylist Name: %s\nPlaylist ID: %v", playlist.Name, playlist.ID)
 	}(userPlaylists, user)
 
 	api := slack.New(slacktoken)


### PR DESCRIPTION
Added a command to ban an artist from the playlist which also removes all tracks by this artist currently in the playlist. Syntax used is `@bot ban Artist`

Each user is only able to have a single artist banned and any new ban commands will overwrite the previous ban by that user. This currently uses a `map[string]string` but should be updated in the future to use a ban list file to retain ban details between restarts.

If a user attempts to add a track by an artist on the ban list they will receive a message that this artist has been banned.

We could potentially take advantage of Slacks message threads in the future to send replies to the initial ban request for the bot to confirm overwrites.

This will not work entirely correctly on the Spotify Web Player as it needs a refresh to update that the tracks have been removed from the playlist.